### PR TITLE
Add kms encrypt script

### DIFF
--- a/scripts/kms-encrypt.sh
+++ b/scripts/kms-encrypt.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+#
+# Exports deployment configuration as environment variables.
+#
+# The deployment stage is identified based on the git tag:
+# * Untagged commits go to staging.
+# * Prerelease tags go to prerelease.
+# * Other tags go to production.
+#
+# Arguments after the end of options (identified by "--") are executed as
+# command, which inherits the exported variables.
+#
+# Usage: ./kms-encrypt.sh string-to-encrypt
+#
+
+#set -e
+
+cd "$(dirname "$0")/.."
+
+PLAIN_TEXT=$1
+
+if [ -z "$PLAIN_TEXT" ]; then
+  printf "\nPlease provide plain text to encrypt.\n\n"
+  exit 1
+fi
+
+if [ -z "$AWS_KMS_KEY_ARN" ]; then
+  AWS_KMS_KEY_ARN=$(jq -r '.config.awsKmsKeyArn' package.json)
+
+  if [ "$AWS_KMS_KEY_ARN" = "null" ]; then
+    printf "\AWS_KMS_KEY_ARN environment variable not set, nor defined in package.json.\n\n"
+    exit 1
+  fi
+fi
+
+if [ -z "$AWS_REGION" ]; then
+  AWS_REGION=$(jq -r '.config.awsRegion' package.json)
+
+  if [ "$AWS_REGION" = "null" ]; then
+    printf "\AWS_REGION environment variable not set, nor defined in package.json.\n\n"
+    exit 1
+  fi
+fi
+
+aws-vault exec allthings-deploy -- \
+  aws kms encrypt \
+  --region "$AWS_REGION" \
+  --key-id "$AWS_KMS_KEY_ARN" \
+  --plaintext "$PLAIN_TEXT"


### PR DESCRIPTION
Had to remove the jq part and printing only the encrypted string because on linux the user is prompted for the aws-vault password each time (an potentially MFA-code). The prompt didn't show up to the user and was always part of stdout, breaking jq parsing.
I changed it to just execute the command and return the whole response.