### PR TITLE
Remove unsupported renovate config from tslint-preset subdir

### DIFF
--- a/packages/tslint-preset/package.json
+++ b/packages/tslint-preset/package.json
@@ -20,13 +20,5 @@
   "peerDependencies": {
     "tslint": ">= 5.9.1",
     "typescript": ">= 2.7.2"
-  },
-  "renovate": {
-    "extends": ["@allthings"],
-    "automerge": true,
-    "bumpVersion": "minor",
-    "major": {
-      "automerge": false
-    }
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,11 @@
 {
-  "extends": ["@allthings"]
+  "extends": ["@allthings"],
+  "pathRules": [{
+    "paths": ["packages/tslint-preset/package.json"],
+    "automerge": true,
+    "bumpVersion": "minor",
+    "major": {
+      "automerge": false
+    }
+  }]
 }


### PR DESCRIPTION
@adieuadieu FYI the purpose of this PR is to close #12 although I'm not 100% this is how you will want to do it.

The problem is that `renovate` config within *nested* `package.json` files is not supported, but some people configure it and aren't aware that it's not working. Therefore we created a check for it and error notification (i.e. as in #12).

It's possible you intended this subdirectory `package.json` only as an *example* renovate config and not to be actually activated? If so then a better solution might be:

1. Exclude that `package.json` from renovation if you don't want those packages renovated anyway
2. Rename the `renovate` section to `renovate-example` so that it is not detected by the bot