### PR TITLE
Update tslint.json

### DIFF
--- a/packages/tslint-preset-react/tslint.json
+++ b/packages/tslint-preset-react/tslint.json
@@ -3,6 +3,7 @@
   "rules": {
     "no-class": false,
     "no-expression-statement": false,
-    "no-this": false
+    "no-this": false,
+    "no-mixed-interface": false
   }
 }


### PR DESCRIPTION
We like to disable this rule because it prevents react components to have callbacks.