### PR TITLE
Drop "no-use-before-declare" rule.

### DIFF
--- a/packages/tslint-preset/tslint.json
+++ b/packages/tslint-preset/tslint.json
@@ -67,7 +67,6 @@
     "no-unnecessary-callback-wrapper": true,
     "no-for-in-array": true,
     "no-string-throw": true,
-    "no-use-before-declare": true,
     
     "no-string-literal": true,
     "no-invalid-template-strings": true,


### PR DESCRIPTION
This rule has been deprecated since TypeScript 2.9 (the built-in compiler checks it directly instead).

```sh
$ tslint -p tsconfig.json -t stylish
no-use-before-declare is deprecated. Since TypeScript 2.9. Please use the built-in compiler checks instead.
```